### PR TITLE
chore: bump version to 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable defects found in review and fixed are listed here. Each fix is
 guarded by an always-on regression test in the suite (`src/test.rs` and
 `tests/builder_network.rs`).
 
-## Unreleased
+## 0.1.0
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_sqlx"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
Bumps the crate version from 0.0.1 to 0.1.0 (one minor point) in `Cargo.toml`, and renames the changelog's `Unreleased` section to `0.1.0` to mark the release.